### PR TITLE
Add script to check file size of checkpoint on Google Cloud Storage

### DIFF
--- a/pretrain/v3-megatron-gcp/scripts/check_cloud_filesize.sh
+++ b/pretrain/v3-megatron-gcp/scripts/check_cloud_filesize.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
- 
-LOCAL_CKPT_DIR="/lustre/checkpoints/llama-2-172b-exp2/tp4-pp16-cp1"
-CLOUD_CKPT_DIR="gs://llama2-172b-checkpoint-exp2"
 
+# This script compares the file size of each checkpoint between gcp cloud storage and local storage.
+# If the file sizes are different, an error is output.
+# 
+# How to use:
+# $ bash check_cloud_filesize.sh
+# > iter_xxxx Local size:yyyy Cloud size:yyyy
+# If the file sizes are different
+# > iter_xxxx Local size:yyyy Cloud size:zzzz
+# > Error: iter_xxxx file sizes are different.
+ 
+LOCAL_CKPT_DIR="/lustre/checkpoints/llama-2-172b-exp2/tp4-pp16-cp1" # FIXME: DIR_PATH to checkpoint on local storage
+CLOUD_CKPT_DIR="gs://llama2-172b-checkpoint-exp2" # FIXME: DIR_PATH to checkpoint on gcp cloud storage
 
 for iter in $(ls ${LOCAL_CKPT_DIR} | grep iter_); do
 	local_size=$(du -scb ${LOCAL_CKPT_DIR}/${iter}/*/*.pt | tail -n1 | cut -f1)

--- a/pretrain/v3-megatron-gcp/scripts/check_cloud_filesize.sh
+++ b/pretrain/v3-megatron-gcp/scripts/check_cloud_filesize.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script compares the file size of each checkpoint between gcp cloud storage and local storage.
+# This script compares the file size of each checkpoint between Google Cloud Storage and local storage.
 # If the file sizes are different, an error is output.
 # 
 # How to use:
@@ -11,7 +11,7 @@
 # > Error: iter_xxxx file sizes are different.
  
 LOCAL_CKPT_DIR="/lustre/checkpoints/llama-2-172b-exp2/tp4-pp16-cp1" # FIXME: DIR_PATH to checkpoint on local storage
-CLOUD_CKPT_DIR="gs://llama2-172b-checkpoint-exp2" # FIXME: DIR_PATH to checkpoint on gcp cloud storage
+CLOUD_CKPT_DIR="gs://llama2-172b-checkpoint-exp2" # FIXME: DIR_PATH to checkpoint on Google Cloud Storage
 
 for iter in $(ls ${LOCAL_CKPT_DIR} | grep iter_); do
 	local_size=$(du -scb ${LOCAL_CKPT_DIR}/${iter}/*/*.pt | tail -n1 | cut -f1)

--- a/pretrain/v3-megatron-gcp/scripts/check_cloud_filesize.sh
+++ b/pretrain/v3-megatron-gcp/scripts/check_cloud_filesize.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+ 
+LOCAL_CKPT_DIR="/lustre/checkpoints/llama-2-172b-exp2/tp4-pp16-cp1"
+CLOUD_CKPT_DIR="gs://llama2-172b-checkpoint-exp2"
+
+
+for iter in $(ls ${LOCAL_CKPT_DIR} | grep iter_); do
+	local_size=$(du -scb ${LOCAL_CKPT_DIR}/${iter}/*/*.pt | tail -n1 | cut -f1)
+	cloud_size=$(gsutil du -sc "${CLOUD_CKPT_DIR}/${iter}" | tail -n1 | awk '{print $1}')
+
+	echo "${iter} Local size:${local_size} Cloud size:${cloud_size}"
+
+	if [ "$local_size" -ne "$cloud_size" ]; then
+		echo "Error: ${iter} file sizes are different."
+	fi
+done
+


### PR DESCRIPTION
Compare checkpoint file sizes between Google Cloud Storage and local storage.

## How to use
```
 $ bash check_cloud_filesize.sh
 iter_xxxx Local size:yyyy Cloud size:yyyy
```

If the file sizes are different.
```
 $ bash check_cloud_filesize.sh
 iter_xxxx Local size:yyyy Cloud size:zzzz
 Error: iter_xxxx file sizes are different.
```